### PR TITLE
CCAA-65: Check that copy requests succeed or fail the event processing

### DIFF
--- a/lib/CoverArtArchive/Indexer/EventHandler/Move.pm
+++ b/lib/CoverArtArchive/Indexer/EventHandler/Move.pm
@@ -31,6 +31,11 @@ sub handle_event {
         )->http_request
     );
 
+    if (!$res->is_success) {
+        die "Copying of $old_mbid/$id to $new_mbid/$id failed: " .
+            $res->decoded_content;
+    }
+
     # Delete the old image
     $self->c->lwp->request(
         Net::Amazon::S3::Request::DeleteObject->new(


### PR DESCRIPTION
Simply dies if the copy request doesn't succeed. The copy request often fails to succeed during slow down periods.

I'd like to get this out ASAP, because until then we are just throwing information away (though it is at least correctable because usually the delete also won't go through).
