### PR TITLE
Use the x-archive-keep-old-version header when making requests to the IA; this preserves the files in a special history folder.

### DIFF
--- a/lib/CoverArtArchive/Indexer/EventHandler/Delete.pm
+++ b/lib/CoverArtArchive/Indexer/EventHandler/Delete.pm
@@ -24,7 +24,10 @@ sub handle {
     my $req = Net::Amazon::S3::Request::DeleteObject->new(
         s3      => $self->s3,
         bucket  => "mbid-$mbid",
-        key     => $key
+        key     => $key,
+        headers => {
+            "x-archive-keep-old-version" => 1,
+        }
     )->http_request;
 
     my $res = $self->lwp->request($req);

--- a/lib/CoverArtArchive/Indexer/EventHandler/Index.pm
+++ b/lib/CoverArtArchive/Indexer/EventHandler/Index.pm
@@ -94,6 +94,7 @@ sub handle {
                         'x-archive-meta-collection' => 'coverartarchive',
                         "x-archive-auto-make-bucket" => 1,
                         'Content-Type' => 'application/xml; charset=utf-8',
+                        "x-archive-keep-old-version" => 1,
                     }
                 )->http_request
             );

--- a/lib/CoverArtArchive/Indexer/EventHandler/Move.pm
+++ b/lib/CoverArtArchive/Indexer/EventHandler/Move.pm
@@ -28,6 +28,7 @@ sub handle {
                 "x-archive-auto-make-bucket" => 1,
                 "x-archive-meta-collection" => 'coverartarchive',
                 "x-archive-meta-mediatype" => 'images',
+                "x-archive-keep-old-version" => 1,
             },
             value => ''
         )->http_request
@@ -43,7 +44,10 @@ sub handle {
         Net::Amazon::S3::Request::DeleteObject->new(
             s3 => $self->s3,
             bucket => "mbid-$old_mbid",
-            key => "mbid-$old_mbid-$id.$suffix"
+            key => "mbid-$old_mbid-$id.$suffix",
+            headers => {
+                "x-archive-keep-old-version" => 1,
+            }
         )->http_request
     )
 }


### PR DESCRIPTION
This is documented on http://archive.org/help/abouts3.txt and we were talking about it probably being a good idea the other day.