### PR TITLE
Use HTTPS URLs in the generated json files

### DIFF
--- a/lib/CoverArtArchive/Indexer/EventHandler/Index.pm
+++ b/lib/CoverArtArchive/Indexer/EventHandler/Index.pm
@@ -53,7 +53,7 @@ sub handle {
                     $release->{id}
                 )->hashes
             ],
-            release => 'http://musicbrainz.org/release/' . $release->{gid}
+            release => 'https://musicbrainz.org/release/' . $release->{gid}
         });
 
         log_debug { "Produced $json" };


### PR DESCRIPTION
See http://chatlogs.musicbrainz.org/musicbrainz-devel/2014/2014-07/2014-07-01.html#T10-14-05-273215 - tests don't seem to work but from a quick glance it looks like they don't look at this field anyway.