### PR TITLE
Allow configuring where indexes should be uploaded to

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -15,4 +15,4 @@ vhost = /
 [caa]
 public_key = {public key here}
 private_key = {private key here}
-
+upload_url = //{bucket}.s3.us.archive.org{file}

--- a/lib/CoverArtArchive/IAS3Request.pm
+++ b/lib/CoverArtArchive/IAS3Request.pm
@@ -17,8 +17,11 @@ around 'http_request' => sub {
     $self->_add_auth_header( $http_headers, $method, $path )
         unless exists $headers->{Authorization};
     my $protocol = $self->s3->secure ? 'https' : 'http';
-    $path =~ m{^([^/?]+)(.*)};
-    my $uri = "$protocol://$1.s3.us.archive.org$2";
+    my ($bucket, $file) = ($path =~ m{^([^/?]+)(.*)});
+
+    my $uri = $protocol . ':' . $self->s3->{_caa_config}{upload_url};
+    $uri =~ s/\{bucket\}/$bucket/;
+    $uri =~ s/\{file\}/$file/;
 
     my $request
         = HTTP::Request->new( $method, $uri, $http_headers, $content );

--- a/lib/CoverArtArchive/Indexer/Context.pm
+++ b/lib/CoverArtArchive/Indexer/Context.pm
@@ -17,10 +17,12 @@ sub _build_s3 {
 
     my $config = $self->config->{caa};
 
-    Net::Amazon::S3->new(
+    my $s3 = Net::Amazon::S3->new(
         aws_access_key_id => $config->{public_key},
         aws_secret_access_key => $config->{private_key},
     );
+    $s3->{_caa_config} = $config;
+    $s3;
 }
 
 has lwp => (
@@ -38,6 +40,8 @@ has config => (
     clearer => 'reload_config',
 );
 
+my $DEFAULT_UPLOAD_URL = '//{bucket}.s3.us.archive.org{file}';
+
 sub _build_config {
     my $self = shift;
 
@@ -46,6 +50,8 @@ sub _build_config {
 
     my $opts_config = $self->opts_config;
     my $config = Config::Tiny->read($opts_config->{config});
+
+    $config->{upload_url} //= $DEFAULT_UPLOAD_URL;
 
     # Override settings from the config file with those specified on the
     # command line.


### PR DESCRIPTION
HACKING-CAA.md from the musicbrainz-server repo currently requires us to manually change the line in IAS3Request.pm to do this. Here I've added a way to do it via configuration only, with `{bucket}` and `{file}` placeholders.