### PR TITLE
CAA-128: Cascade deletes to derived files

### DIFF
--- a/lib/CoverArtArchive/Indexer/EventHandler/Delete.pm
+++ b/lib/CoverArtArchive/Indexer/EventHandler/Delete.pm
@@ -29,7 +29,10 @@ sub handle {
 
     # Net::Amazon::S3::Request::DeleteObject does not support a headers
     # attribute, unlike the other Net::Amazon::S3::Request::* packages.
-    $req->header('x-archive-keep-old-version' => 1);
+    $req->header(
+        'x-archive-keep-old-version' => 1,
+        'x-archive-cascade-delete'   => 1,
+    );
 
     my $res = $self->lwp->request($req);
 

--- a/lib/CoverArtArchive/Indexer/EventHandler/Move.pm
+++ b/lib/CoverArtArchive/Indexer/EventHandler/Move.pm
@@ -48,7 +48,10 @@ sub handle {
 
     # Net::Amazon::S3::Request::DeleteObject does not support a headers
     # attribute, unlike the other Net::Amazon::S3::Request::* packages.
-    $req->header('x-archive-keep-old-version' => 1);
+    $req->header(
+        'x-archive-keep-old-version' => 1,
+        'x-archive-cascade-delete'   => 1,
+    );
 
     $self->c->lwp->request($req);
 }


### PR DESCRIPTION
Fix CAA-128.

The [`x-archive-cascade-delete`](https://archive.org/services/docs/api/ias3.html#delete-derived-files-when-an-original-is-deleted) header enables automated deleting of derived files when the original file is deleted. With this header, when the original images are deleted, the generated thumbnails will be deleted too.

Please scrutinize this PR, even though this is a simple change, it's still the first line of perl I've ever written, so I might have messed something up.

Side note: Is it even necessary to delete the images in the Move handler at all? It would also be caught by the Delete handler when the row of the merged release is deleted (although currently, those triggers don't seem to be handled properly, see CAA-126).