### PR TITLE
CAA-130: Set noindex and mediatype on Move

### DIFF
--- a/lib/CoverArtArchive/Indexer/EventHandler/Move.pm
+++ b/lib/CoverArtArchive/Indexer/EventHandler/Move.pm
@@ -27,7 +27,8 @@ sub handle {
                 'x-amz-copy-source' => "/mbid-$old_mbid/mbid-$old_mbid-$id.$suffix",
                 "x-archive-auto-make-bucket" => 1,
                 "x-archive-meta-collection" => 'coverartarchive',
-                "x-archive-meta-mediatype" => 'images',
+                "x-archive-meta-mediatype" => 'image',
+                "x-archive-meta-noindex" => 'true',
                 "x-archive-keep-old-version" => 1,
             },
             value => ''


### PR DESCRIPTION
When moving images, add the `noindex` and `mediatype` headers to ensure the correct item-level metadata is set if the item does not exist yet (i.e., the merge target did not have images associated with it yet).

Using `'true'` rather than `1` for consistency with MBS and most other `noindex` items on IA (https://github.com/metabrainz/musicbrainz-server/pull/652).