### PR TITLE
Set noindex and mediatype on Index

### DIFF
--- a/lib/CoverArtArchive/Indexer/EventHandler/Index.pm
+++ b/lib/CoverArtArchive/Indexer/EventHandler/Index.pm
@@ -75,6 +75,8 @@ sub handle {
                     value   => $json,
                     headers => {
                         'x-archive-meta-collection' => 'coverartarchive',
+                        'x-archive-meta-mediatype' => 'image',
+                        'x-archive-meta-noindex' => 'true',
                         "x-archive-auto-make-bucket" => 1,
                         "x-archive-keep-old-version" => 1,
                         'Content-Type' => 'application/json; charset=utf-8',
@@ -105,6 +107,8 @@ sub handle {
                     value   => $mb_res->content,
                     headers => {
                         'x-archive-meta-collection' => 'coverartarchive',
+                        'x-archive-meta-mediatype' => 'image',
+                        'x-archive-meta-noindex' => 'true',
                         "x-archive-auto-make-bucket" => 1,
                         'Content-Type' => 'application/xml; charset=utf-8',
                     }


### PR DESCRIPTION
This is a followup to 356434072e55165c657812147de9798a424b7935.
@ROpdebee reported that there are some 200+ items without the noindex
attribute set, many uploaded well after that patch was deployed.  I took
a random sample of these items and all were merged releases.

ROpdebee suggested we should also copy the previous changes onto the
_meta.xml and index.json PUTs: it seems that sometimes there is an Index
event queued before the Move, so the Move (which has the correct
attributes) doesn't create the bucket.  A PUT from the Index does.

I checked the musicbrainz-server code to see why an Index event would be
sent first, and found at least one case: reindex_release_via_catno is
called whenever the release_label table is updated, and for release
merges we do update this table before updating cover_art.  caa_move
isn't called until cover_art is updated, so the Move event would be sent
after.